### PR TITLE
[WIP] rewrite using KA.jl

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,16 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,20 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      lookback:
+        default: 5
+permissions:
+  contents: write
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+    tags: '*'
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.10'
+          - '1'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        env:
+            JULIA_NUM_THREADS: "4"
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          file: lcov.info

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 Manifest.toml
+
+# pixi environments
+.pixi
+*.egg-info

--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,23 @@
 name = "CUDAHist"
 uuid = "b88ef80f-2b40-4481-b604-71583ef69ab9"
-version = "0.1.0"
 authors = ["Michael"]
+version = "0.1.0"
 
 [deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 FHist = "68837c9b-b678-4cd5-9925-8a54edc8f695"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
+BenchmarkTools = "1.6.0"
+JSON3 = "1.14.3"
 KernelAbstractions = "0.9.34"
+Pluto = "0.20.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,17 @@
 name = "CUDAHist"
 uuid = "b88ef80f-2b40-4481-b604-71583ef69ab9"
-authors = ["Michael"]
 version = "0.1.0"
+authors = ["Michael"]
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 FHist = "68837c9b-b678-4cd5-9925-8a54edc8f695"
+KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+
+[compat]
+KernelAbstractions = "0.9.34"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -6,18 +6,22 @@ version = "0.1.0"
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
 FHist = "68837c9b-b678-4cd5-9925-8a54edc8f695"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
+PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 BenchmarkTools = "1.6.0"
+CondaPkg = "0.2.29"
 JSON3 = "1.14.3"
 KernelAbstractions = "0.9.34"
 Pluto = "0.20.10"
+PythonCall = "0.9.25"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,122 @@
+using Test
+using FHist, BenchmarkTools
+using KernelAbstractions
+using CUDA
+using CUDAHist: gpu_bincounts, move
+const backend = isnothing(get(ENV, "CI", nothing)) ? CUDABackend() : CPU()
+
+using PythonCall
+const np = pyimport("numpy")
+
+const input_Ls = [2^N for N in 7:3:25]
+const rand_inputs = map(input_Ls) do N
+    rand(Float32, N)
+end
+const rand_weights = map(input_Ls) do N
+    rand(Float32, N)
+end
+const rannd_inputs_np = np.array.(rand_inputs)
+const rannd_weights_np = np.array.(rand_weights)
+
+const EVALS = 1
+const SAMPLES = 300
+
+const SUITE = BenchmarkGroup()
+SUITE["N_input_scan"] = BenchmarkGroup()
+const L_binedges = 1000
+SUITE["N_bins_scan"] = BenchmarkGroup()
+
+for (N, input, weights, input_np, weights_np) in zip(input_Ls, rand_inputs, rand_weights, rannd_inputs_np, rannd_weights_np)
+    binedges = range(0.0, 1.0; length=L_binedges)
+    SUITE["NumpyBaseline"]["FHist.jl (CPU)"][N] = @benchmarkable(
+        Hist1D($input; binedges=$binedges);
+        evals=EVALS,
+        samples=SAMPLES
+    )
+    SUITE["NumpyBaseline"]["Numpy (CPU, v2.3.0)"][N] = @benchmarkable(
+    np.histogram($input_np; bins=$(L_binedges+1), range=$((0.0, 1.0)));
+        evals=EVALS,
+        samples=SAMPLES
+    )
+end
+
+for (N, input, weights, input_np, weights_np) in zip(input_Ls, rand_inputs, rand_weights, rannd_inputs_np, rannd_weights_np)
+    binedges = range(0.0, 1.0; length=L_binedges)
+    SUITE["NumpyWeights"]["FHist.jl (CPU)"][N] = @benchmarkable(
+        Hist1D($input; weights=$weights, binedges=$binedges);
+        evals=EVALS,
+        samples=SAMPLES
+    )
+    SUITE["NumpyWeights"]["Numpy (CPU, v2.3.0)"][N] = @benchmarkable(
+    np.histogram($input_np; weights=$(weights_np), bins=$(L_binedges+1), range=$((0.0, 1.0)));
+        evals=EVALS,
+        samples=SAMPLES
+    )
+end
+
+const binedges_Ls = [256, 512, 512*2, 512*4, 512*8, 512*12]
+
+for sharemem in (true, false)
+    for (N, input, weights, input_np, weights_np) in zip(input_Ls, rand_inputs, rand_weights, rannd_inputs_np, rannd_weights_np)
+        binedges = range(0.0, 1.0; length=L_binedges)
+        SUITE["N_input_scan_sharemem$sharemem"]["FHist.jl (CPU)"][N] = @benchmarkable(
+            Hist1D($input; weights=$weights, binedges=$binedges);
+            evals=EVALS,
+            samples=SAMPLES
+        )
+        SUITE["N_input_scan_sharemem$sharemem-v2"]["FHist.jl (CPU)"][N] = @benchmarkable(
+            Hist1D($input; weights=$weights, binedges=$binedges);
+            evals=EVALS,
+            samples=SAMPLES
+        )
+        for bs in (32, 128, 512, 1024)
+            SUITE["N_input_scan_sharemem$sharemem"]["GPU-blocksize$bs"][N] = @benchmarkable(
+                gpu_bincounts($(move(backend, input)); blocksize=$bs, sync=true, weights=$(move(backend, weights)), backend, v2=false, sharemem=$sharemem, binedges=$binedges);
+                evals=EVALS,
+                samples=SAMPLES
+            )
+            SUITE["N_input_scan_sharemem$sharemem-v2"]["GPU-blocksize$bs"][N] = @benchmarkable(
+                gpu_bincounts($(move(backend, input)); blocksize=$bs, sync=true, weights=$(move(backend, weights)), backend, v2=true, sharemem=$sharemem, binedges=$binedges);
+                evals=EVALS,
+                samples=SAMPLES
+            )
+        end
+    end
+
+
+    for N in binedges_Ls
+        input = rand_inputs[5]
+        weights = rand_weights[5]
+
+        binedges = range(0.; stop=1.0, length=N)
+
+        SUITE["N_bins_scan_sharemem$sharemem"]["FHist.jl (CPU)"][N] = @benchmarkable(
+            Hist1D($input; weights=$weights, binedges=$binedges);
+            evals=EVALS,
+            samples=SAMPLES
+        )
+        SUITE["N_bins_scan_sharemem$sharemem-v2"]["FHist.jl (CPU)"][N] = @benchmarkable(
+            Hist1D($input; weights=$weights, binedges=$binedges);
+            evals=EVALS,
+            samples=SAMPLES
+        )
+        for bs in (32, 128, 512, 1024)
+            SUITE["N_bins_scan_sharemem$sharemem"]["GPU-blocksize$bs"][N] = @benchmarkable(
+                gpu_bincounts($(move(backend, input)); blocksize=$bs, sync=true, weights=$(move(backend, weights)), backend, v2=false, sharemem=$sharemem, binedges=$binedges);
+                evals=EVALS,
+                samples=SAMPLES
+            )
+            SUITE["N_bins_scan_sharemem$sharemem-v2"]["GPU-blocksize$bs"][N] = @benchmarkable(
+                gpu_bincounts($(move(backend, input)); blocksize=$bs, sync=true, weights=$(move(backend, weights)), v2=true, backend, sharemem=$sharemem, binedges=$binedges);
+                evals=EVALS,
+                samples=SAMPLES
+            )
+        end
+    end
+end
+
+
+results = run(SUITE, verbose=true, seconds=10)
+# BenchmarkTools.save("benchmark_params.json", params(SUITE));
+BenchmarkTools.save("benchmark_result_$(L_binedges)bins_all.json", results)
+

--- a/src/CUDAHist.jl
+++ b/src/CUDAHist.jl
@@ -5,7 +5,7 @@ import FHist: Hist1D
 
 # INCLUDE ROCM
 using KernelAbstractions
-using KernelAbstractions: @atomic, @atomicswap, @atomicreplace
+using KernelAbstractions: @atomic, @atomicswap, @atomicreplace, @Const
 import CUDA
 using CUDA.CUDAKernels
 CUDA.allowscalar(false)
@@ -41,7 +41,7 @@ function naive_binidxs(input, binedges)
 end
 
 # This a 1D histogram kernel where the histogramming happens on shmem
-@kernel function histogram_kernel!(histogram_output, input, weights)
+@kernel unsafe_indices = true function histogram_kernel!(histogram_output, @Const(input), @Const(weights))
     gid = @index(Group, Linear)
     lid = @index(Local, Linear)
 

--- a/src/CUDAHist.jl
+++ b/src/CUDAHist.jl
@@ -20,11 +20,13 @@ function create_histogram(input)
 end
 
 # input already on gpu
-function gpu_bincounts(input; weights=nothing, sync=false, binedges, blocksize=256, backend = CUDABackend())
+function gpu_bincounts(input; weights=nothing, sync=false, binedges, blocksize=256, backend=CUDABackend())
     cu_bincounts = KernelAbstractions.zeros(backend, Float32, length(binedges) - 1)
-    binindexs = naive_binidxs(input, binedges)
-    synchronize(backend)
-    histogram!(cu_bincounts, binindexs; weights, blocksize)
+    firstr = Float32(first(binedges))
+    invstep = Float32(inv(step(binedges)))
+    # binindexs = naive_binidxs(input, binedges)
+    # synchronize(backend)
+    histogram!(cu_bincounts, input, firstr, invstep; weights, blocksize)
     if sync
         synchronize(backend)
     end
@@ -41,13 +43,13 @@ function naive_binidxs(input, binedges)
 end
 
 # This a 1D histogram kernel where the histogramming happens on shmem
-@kernel unsafe_indices = true function histogram_kernel!(histogram_output, @Const(input), @Const(weights))
+@kernel unsafe_indices = true function histogram_kernel!(histogram_output, @Const(input_raw), @Const(weights), firstr, invstep)
     gid = @index(Group, Linear)
     lid = @index(Local, Linear)
 
-    @uniform gs = prod(@groupsize())
-    tid = (gid - 1) * gs + lid
-    @uniform N = length(histogram_output)
+    @uniform gs = Int32(prod(@groupsize()))
+    tid = (gid - Int32(1)) * gs + lid
+    @uniform N = Int32(length(histogram_output))
 
     shared_histogram = @localmem Float32 (gs)
 
@@ -56,41 +58,45 @@ end
     # blocks to write to. For example, if shmem is of size 256, but it's
     # possible to get a value of 312, then we will have 2 separate shmem blocks,
     # one from 1->256, and another from 256->512
-    for min_element in 1:gs:N
+    for min_element in Int32(1):gs:N
 
         # Setting shared_histogram to 0
-        @inbounds shared_histogram[lid] = 0
+        @inbounds shared_histogram[lid] = Int32(0)
         @synchronize()
 
         max_element = min_element + gs
         if max_element > N
-            max_element = N + 1
+            max_element = N + Int32(1)
         end
 
         # Defining bin on shared memory and writing to it if possible
-        bin = tid <= length(input) ? input[tid] : 0
-        if bin >= min_element && bin < max_element
-            bin -= min_element - 1
-            @atomic shared_histogram[bin] += isnothing(weights) ? one(Float32) : weights[tid]
+        if tid <= length(input_raw)
+            x = input_raw[tid]
+            cursor = floor(Int32, (x - firstr) * invstep)
+            bin = cursor + Int32(1)
+            if bin >= min_element && bin < max_element
+                bin -= min_element - Int32(1)
+                @atomic shared_histogram[bin] += isnothing(weights) ? one(Float32) : weights[tid]
+            end
         end
 
         @synchronize()
 
-        if ((lid + min_element - 1) <= N)
-            @atomic histogram_output[lid + min_element - 1] += shared_histogram[lid]
+        if ((lid + min_element - Int32(1)) <= N)
+            @atomic histogram_output[lid+min_element-Int32(1)] += shared_histogram[lid]
         end
 
     end
 end
 
-function histogram!(histogram_output, input; weights=nothing, blocksize = 256)
+function histogram!(histogram_output, input, firstr, invstep; weights=nothing, blocksize=256)
     backend = get_backend(histogram_output)
     # Need static block size
     if !isnothing(weights)
         @assert get_backend(weights) == backend "Weights must be on the same backend as histogram_output"
     end
     kernel! = histogram_kernel!(backend, (blocksize,))
-    kernel!(histogram_output, input, weights, ndrange = size(input))
+    kernel!(histogram_output, input, weights, firstr, invstep, ndrange=size(input))
     return
 end
 

--- a/src/CUDAHist.jl
+++ b/src/CUDAHist.jl
@@ -23,7 +23,7 @@ end
 function gpu_bincounts(input; weights=nothing, sync=false, binedges, blocksize=256, backend=CUDABackend())
     cu_bincounts = KernelAbstractions.zeros(backend, Float32, length(binedges) - 1)
     firstr = Float32(first(binedges))
-    invstep = Float32(inv(step(binedges)))
+    invstep = inv(step(binedges))
     # binindexs = naive_binidxs(input, binedges)
     # synchronize(backend)
     histogram!(cu_bincounts, input, firstr, invstep; weights, blocksize)

--- a/src/CUDAHist.jl
+++ b/src/CUDAHist.jl
@@ -20,45 +20,53 @@ function create_histogram(input)
 end
 
 # input already on gpu
-function gpu_bincounts(input; weights=nothing, sync=false, binedges, blocksize=256, backend=CUDABackend())
+function gpu_bincounts(input; weights=nothing, sync=false, sharemem=true, binedges, blocksize=256, backend=CUDABackend())
     cu_bincounts = KernelAbstractions.zeros(backend, Float32, length(binedges) - 1)
     firstr = Float32(first(binedges))
     invstep = Float32(inv(step(binedges)))
     # binindexs = naive_binidxs(input, binedges)
     # synchronize(backend)
-    histogram!(cu_bincounts, input, firstr, invstep; weights, blocksize)
+    histogram!(cu_bincounts, input, firstr, invstep; weights, blocksize, sharemem)
     if sync
         synchronize(backend)
     end
     return cu_bincounts
 end
 
-function naive_binidxs(input, binedges)
-    firstr = first(binedges)
-    invstep = inv(step(binedges))
-    cursor = floor.(Int, (input .- firstr) .* invstep)
-    binidxs = cursor .+ 1
-
-    return binidxs
-end
-
-# This a 1D histogram kernel where the histogramming happens on shmem
-@kernel unsafe_indices = true function histogram_kernel!(histogram_output, @Const(input_raw), @Const(weights), firstr, invstep)
+@kernel unsafe_indices = true function histogram_naive_kernel!(histogram_output, @Const(input_raw), @Const(weights), @Const(firstr), @Const(invstep))
     gid = @index(Group, Linear)
     lid = @index(Local, Linear)
 
-    @uniform gs = Int32(prod(@groupsize()))
+    gs = Int32(prod(@groupsize()))
     tid = (gid - Int32(1)) * gs + lid
-    @uniform N = Int32(length(histogram_output))
+    if tid <= length(input_raw)
+        x = input_raw[tid]
+        cursor = floor(Int32, (x - firstr) * invstep)
+        bin = cursor + Int32(1)
+        @atomic histogram_output[bin] += isnothing(weights) ? one(Float32) : weights[tid]
+    end
+end
 
-    shared_histogram = @localmem Float32 (gs)
+# This a 1D histogram kernel where the histogramming happens on shmem
+@kernel unsafe_indices = true function histogram_sharemem_kernel!(histogram_output,
+    @Const(input_raw), @Const(weights), @Const(firstr), @Const(invstep)
+)
+    gid = @index(Group, Linear)
+    lid = @index(Local, Linear)
+
+    gs = Int32(prod(@groupsize()))
+    tid = (gid - Int32(1)) * gs + lid
+    N = Int32(length(histogram_output))
+
+    shared_histogram = @localmem eltype(histogram_output) (gs)
 
     # This will go through all input elements and assign them to a location in
     # shmem. Note that if there is not enough shem, we create different shmem
     # blocks to write to. For example, if shmem is of size 256, but it's
     # possible to get a value of 312, then we will have 2 separate shmem blocks,
     # one from 1->256, and another from 256->512
-    for min_element in Int32(1):gs:N
+    min_element = Int32(1)
+    while min_element <= N
 
         # Setting shared_histogram to 0
         @inbounds shared_histogram[lid] = Int32(0)
@@ -86,16 +94,21 @@ end
             @atomic histogram_output[lid+min_element-Int32(1)] += shared_histogram[lid]
         end
 
+        min_element += gs
     end
 end
 
-function histogram!(histogram_output, input, firstr, invstep; weights=nothing, blocksize=256)
+function histogram!(histogram_output, input, firstr, invstep; sharemem, weights=nothing, blocksize=256)
     backend = get_backend(histogram_output)
     # Need static block size
     if !isnothing(weights)
         @assert get_backend(weights) == backend "Weights must be on the same backend as histogram_output"
     end
-    kernel! = histogram_kernel!(backend, (blocksize,))
+    kernel! = if sharemem
+        histogram_sharemem_kernel!(backend, (blocksize,))
+    else
+        histogram_naive_kernel!(backend, (blocksize,))
+    end
     kernel!(histogram_output, input, weights, firstr, invstep, ndrange=size(input))
     return
 end

--- a/src/CUDAHist.jl
+++ b/src/CUDAHist.jl
@@ -1,365 +1,102 @@
 module CUDAHist
 
-export CUDAHist1D, nentries, sumw2, binerrors, bincounts, binedges, bincenters, integral, atomic_push!, append!, push!, normalize, cumulative, nbins
-
-using CUDA
-using Base.Threads: SpinLock
-using StatsBase
-using Statistics
 using FHist
 import FHist: Hist1D
 
-_sturges(x) = StatsBase.sturges(length(x))
+# INCLUDE ROCM
+using KernelAbstractions
+using KernelAbstractions: @atomic, @atomicswap, @atomicreplace
+using CUDA
+using CUDA.CUDAKernels
+CUDA.allowscalar(false)
 
-mutable struct CUDAHist1D{T<:Union{Int32, UInt32, Float32}} <: AbstractHistogram{T,1,CuArray{T,1}}
-    binedges::CuArray{Float32,1}
-    bincounts::CuArray{T,1}
-    sumw2::CuArray{Float32,1}
-    nentries::Base.RefValue{Int32}
-    overflow::Bool
-    hlock::SpinLock
-    function CUDAHist1D(;
-        counttype::Type{T}=Float32,
-        binedges,
-        bincounts=CUDA.zeros(counttype, length(binedges) - 1),
-        sumw2=zero(bincounts),
-        nentries=Int32(0),
-        overflow=false) where {T}
-
-        return new{T}(binedges, bincounts, sumw2, Ref(round(Int32, nentries)), overflow, SpinLock())
+# Function to use as a baseline for CPU metrics
+function create_histogram(input)
+    histogram_output = zeros(Int, maximum(input))
+    for i in input
+        histogram_output[i] += 1
     end
+    return histogram_output
+end
 
-    function CUDAHist1D(ary::E;
-        counttype::Type{T}=Float32,
-        binedges=nothing,
-        weights=nothing,
-        nbins=nothing,
-        overflow=false) where {T,E<:NTuple{1,Any}}
+# input already on gpu
+function gpu_bincounts(input; sync=false, binedges, blocksize=256, backend = CUDABackend())
+    cu_bincounts = KernelAbstractions.zeros(backend, Int, length(binedges) - 1)
+    histogram!(cu_bincounts, input; blocksize)
+    if sync
+        synchronize(backend)
+    end
+    return cu_bincounts
+end
 
-        length(ary) == 1 || throw(DimensionMismatch("Data must be a tuple of 1 vectors"))
-        isnothing(weights) || length(ary[1]) == length(weights) || throw(DimensionMismatch("Data and weights must have the same length"))
+function naive_binidxs(input, binedges)
+    firstr = first(r)
+    invstep = inv(step(r))
+    cursor = floor.(Int32, (input .- firstr) .* invstep)
+    binidxs = cursor .+ 1
 
-        binedges = if !isnothing(binedges)
-            CuArray(binedges)
-        else
-            auto_bins(ary, Val(1); nbins)
+    return binidxs
+end
+
+# This a 1D histogram kernel where the histogramming happens on shmem
+@kernel function histogram_kernel!(histogram_output, input)
+    tid = @index(Global, Linear)
+    lid = @index(Local, Linear)
+
+    @uniform warpsize = Int(32)
+
+    @uniform gs = @groupsize()[1]
+    @uniform N = length(histogram_output)
+
+    shared_histogram = @localmem Int (gs)
+
+    # This will go through all input elements and assign them to a location in
+    # shmem. Note that if there is not enough shem, we create different shmem
+    # blocks to write to. For example, if shmem is of size 256, but it's
+    # possible to get a value of 312, then we will have 2 separate shmem blocks,
+    # one from 1->256, and another from 256->512
+    @uniform max_element = 1
+    for min_element in 1:gs:N
+
+        # Setting shared_histogram to 0
+        @inbounds shared_histogram[lid] = 0
+        @synchronize()
+
+        max_element = min_element + gs
+        if max_element > N
+            max_element = N + 1
         end
 
-        h = CUDAHist1D(; counttype, binedges, overflow)
-        _fast_bincounts!(h, ary, binedges, weights)
-        return h
-    end
-
-    function CUDAHist1D(h::Hist1D)
-        binedges = CUDA.CuArray(Vector(FHist.binedges(h)))
-        bincounts = CUDA.CuArray(Vector(FHist.bincounts(h)))
-        sumw2 = CUDA.CuArray(FHist.sumw2(h))
-        nentries = FHist.nentries(h)
-        overflow = h.overflow
-        return CUDAHist1D(; counttype=Float32, binedges, bincounts, sumw2, nentries, overflow)
-    end
-
-    function CUDAHist1D(ary; kws...)
-        CUDAHist1D((ary, ); kws...)
-    end
-end
-
-function Hist1D(h::CUDAHist1D)
-    binedges = Vector(CUDAHist.binedges(h))
-    bincounts = Vector(CUDAHist.bincounts(h))
-    sumw2 = Vector(CUDAHist.sumw2(h))
-    nentries = CUDAHist.nentries(h)
-    overflow = h.overflow
-    return FHist.Hist1D(; binedges, bincounts, sumw2, nentries, overflow)
-end
-
-function auto_bins(ary, ::Val{1}; nbins=nothing)
-    xs = only(ary)
-    E = eltype(xs)
-    F = E <: Number ? float(E) : Float64
-    nbins = isnothing(nbins) ? _sturges(xs) : nbins
-    lo, hi = minimum(xs), maximum(xs)
-    CuArray(collect(StatsBase.histrange(F(lo), F(hi), nbins)))
-end
-
-Base.lock(h::CUDAHist1D) = lock(h.hlock)
-Base.unlock(h::CUDAHist1D) = unlock(h.hlock)
-bincounts(h::CUDAHist1D) = h.bincounts
-binedges(h::CUDAHist1D) = h.binedges
-bincenters(h::CUDAHist1D) = length(h.binedges) > 1 ? (binedges(h)[1:end-1] + diff(binedges(h))./ 2) : nothing
-@doc """
-    nentries(h::$(CUDAHist1D))
-Get the number of times a histogram is filled (`push!`ed)
-"""
-nentries(h::CUDAHist1D) = h.nentries[]
-@doc """
-    sumw2(h)
-Get the sum of weights squared of the histogram, it has the same shape as `bincounts(h)`.
-"""
-sumw2(h::CUDAHist1D) = h.sumw2
-
-@doc """
-    binerrors(f=sqrt, h)
-Get the error (uncertainty) of each bin. By default, calls `sqrt` on `sumw2(h)` bin by bin as an approximation.
-"""
-binerrors(f::T, h::CUDAHist1D) where T<:Function = f.(sumw2(h))
-binerrors(h::CUDAHist1D) = binerrors(sqrt, h)
-
-@doc raw"""
-    effective_entries(h) -> scalar
-
-Get the number of effective entries for the entire histogram:
-
-```math
-n_{eff} = \frac{(\sum Weights )^2}{(\sum Weight^2 )}
-```
-
-This is also equivalent to `integral(hist)^2 / sum(sumw2(hist))`, this is the same as `TH1::GetEffectiveEntries()`
-"""
-effective_entries(h::CUDAHist1D) = abs2(integral(h)) / sum(sumw2(h))
-
-import Base: ==, +, -, *, /
-
-function Base.:(==)(h1::CUDAHist1D, h2::CUDAHist1D)
-    bincounts(h1) == bincounts(h2) &&
-        binedges(h1) == binedges(h2) &&
-        nentries(h1) == nentries(h2) &&
-        sumw2(h1) == sumw2(h2) &&
-        h1.overflow == h2.overflow
-end
-
-function Base.:(==)(h1::CUDAHist1D, h2::Hist1D)
-        Vector(CUDAHist.bincounts(h1)) == FHist.bincounts(h2) &&
-        Vector(CUDAHist.binedges(h1)) == FHist.binedges(h2) &&
-        Int(CUDAHist.nentries(h1)) == FHist.nentries(h2) &&
-        Vector(CUDAHist.sumw2(h1)) == FHist.sumw2(h2) &&
-        h1.overflow == h2.overflow
-end
-
-for op in (:+, :-)
-    @eval function ($op)(h1::CUDAHist1D, h2::CUDAHist1D)
-        edge1 = h1.binedges
-        edge1 != h2.binedges && throw(DimensionMismatch("Binedges don't match"))
-        h1.overflow != h2.overflow && throw("Can't $op histograms with different overflow settings.")
-        newcounts = broadcast($op, bincounts(h1),  bincounts(h2))
-
-        (CUDAHist1D)(; binedges = copy.(edge1), bincounts = newcounts, sumw2 = sumw2(h1) + sumw2(h2), nentries = nentries(h1) + nentries(h2), overflow = h1.overflow)
-    end
-end
-
-function Base.empty!(h1::CUDAHist1D)
-    bincounts(h1) .= false
-    sumw2(h1) .= false
-end
-
-# fall back one-shot implementation
-function _fast_bincounts!(h::CUDAHist1D, A, binedges, weights)
-    xs = A[1]
-    if isnothing(weights)
-        for x in xs
-            push!(h, x)
-        end
-    else
-        for (x, w) in zip(xs, weights)
-            push!(h, x, w)
-        end
-    end
-end
-
-"""
-    nbins(h::CUDAHist1D)
-
-Get the number of bins of a histogram.
-"""
-function nbins(h::CUDAHist1D)
-    length(bincounts(h))
-end
-
-"""
-    integral(h; width=false)
-
-Get the integral a histogram; `width` means multiply each bincount
-by their bin width when calculating the integral.
-
-!!! warning
-    `width` keyword argument only works with 1D histogram at the moment.
-
-!!! warning
-    Be aware of the approximation you make
-    when using `width=true` with histogram with overflow bins, the overflow
-    bins (i.e. the left/right most bins) width will be taken "as is".
-"""
-function integral(h::CUDAHist1D; width=false)
-    if width
-        sum(bincounts(h) .* diff(binedges(h)))
-    else
-        sum(bincounts(h))
-    end
-end
-
-"""
-    push!(h::CUDAHist1D, val::Real, wgt::Real=1)
-    atomic_push!(h::CUDAHist1D, val::Real, wgt::Real=1)
-
-Adding one value at a time into histogram.
-`sumw2` (sum of weights^2) accumulates `wgt^2` with a default weight of 1.
-`atomic_push!` is a slower version of `push!` that is thread-safe.
-
-N.B. To append multiple values at once, use broadcasting via
-`push!.(h, [-3.0, -2.9, -2.8])` or `push!.(h, [-3.0, -2.9, -2.8], 2.0)`
-"""
-@inline function atomic_push!(h::CUDAHist1D, val::Real, wgt::Real=1)
-    lock(h)
-    push!(h, val, wgt)
-    unlock(h)
-    return nothing
-end
-
-@inline function Base.push!(h::CUDAHist1D, val::Real, wgt::Real=1)
-    r = binedges(h)
-    L = nbins(h)
-    binidx = (val .>= r[1:end-1]) .& (val .< r[2:end])
-    
-    if sum(binidx) == L && h.overflow
-        h.bincounts += wgt * vcat(CUDA.zeros(L-1), 1)
-        h.sumw2 += wgt^2 * vcat(CUDA.zeros(L-1), 1)
-        h.nentries[] += 1
-    else
-        h.bincounts += wgt * binidx
-        h.sumw2 += wgt^2 * binidx
-        if sum(binidx) != 0
-            h.nentries[] += 1
-        end
-    end
-    return nothing
-end
-
-function Base.append!(h::CUDAHist1D, val::AbstractVector, wgt::AbstractVector)
-    length(val) == length(wgt) || throw(DimensionMismatch("append! to histogram expect same length values and weights"))
-    lock(h)
-    for (v, w) in zip(val, wgt)
-        push!(h, v, w)
-    end
-    unlock(h)
-    return h
-end
-
-function Base.append!(h::CUDAHist1D, val::AbstractVector)
-    lock(h)
-    for v in val
-        push!(h, v)
-    end
-    unlock(h)
-    return h
-end
-
-function _cuda_append_kernel!(data::CuDeviceArray{Float32}, 
-    wgt::CuDeviceArray{Float32}, 
-    binedges::CuDeviceArray{Float32}, 
-    bincounts::CuDeviceMatrix{Float32},
-    sumw2::CuDeviceMatrix{Float32},
-    nentries::CuDeviceArray{Int32},
-    overflow::Bool)
-
-    #initialize bincounts to zero
-    for i in 1:length(binedges) - 1
-        @inbounds bincounts[i] = 0.0
-        @inbounds sumw2[i] = 0.0
-    end
-
-    thread_index = (blockIdx().x - 1) * blockDim().x + threadIdx().x
-    stride = gridDim().x * blockDim().x
-    nentries[thread_index] = 0
-
-    for i = thread_index:stride:length(data)
-        for i_bin in 1:length(binedges)-1
-            if data[i] >= binedges[i_bin] && data[i] < binedges[i_bin + 1]
-                @inbounds bincounts[i_bin, thread_index] += wgt[i]
-                @inbounds sumw2[i_bin, thread_index] += wgt[i]^2
-                @inbounds nentries[thread_index] += 1
-                break
-            end
+        # Defining bin on shared memory and writing to it if possible
+        bin = input[tid]
+        if bin >= min_element && bin < max_element
+            bin -= min_element - 1
+            @atomic shared_histogram[bin] += 1
         end
 
-        if overflow && data[i] > binedges[end]
-            @inbounds bincounts[end, thread_index] += wgt[i]
-            @inbounds sumw2[end, thread_index] += wgt[i]^2
-            @inbounds nentries[thread_index] += 1
+        @synchronize()
+
+        if ((lid + min_element - 1) <= N)
+            @atomic histogram_output[lid + min_element - 1] += shared_histogram[lid]
         end
+
     end
+
+end
+
+function histogram!(histogram_output, input; blocksize = 256)
+    backend = get_backend(histogram_output)
+    # Need static block size
+    kernel! = histogram_kernel!(backend, (blocksize,))
+    kernel!(histogram_output, input, ndrange = size(input))
     return
 end
 
-function cuda_append!(hist::CUDAHist1D, data::Vector{Float32}, Nthreads::Int; wgt::Vector{Float32}=ones(Float32, length(data)))
-    if length(data) != length(wgt)
-        throw(DimensionMismatch("Data and weights must have the same length"))
-    end
-
-    #Set up arrays for kernel
-    dev = CUDA.device()
-    max_threads = CUDA.attribute(dev, CUDA.DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK)
-    threads_per_block = min(max_threads, Nthreads)
-    blocks = cld(Nthreads, threads_per_block)
-
-
-    data_cu = CuArray(data)
-    wgt_cu = CuArray(wgt)
-    nbins = length(binedges(hist)) - 1
-    bincounts = CUDA.zeros(Float32, nbins, Nthreads)
-    sumw2   = CUDA.zeros(Float32, nbins, Nthreads)
-    nentries = CUDA.zeros(Int32, Nthreads)
-
-    #Launch kernel
-    @cuda threads=threads_per_block blocks=blocks _cuda_append_kernel!(data_cu, wgt_cu, binedges(hist), bincounts, sumw2, nentries, hist.overflow)
-
-    #Wait for all histograms to finish filling
-    CUDA.synchronize()
-
-    #Add up the results of each thread
-    hist.bincounts += vec(sum(bincounts, dims=2))
-    hist.sumw2 += vec(sum(sumw2, dims=2))
-    hist.nentries[] += length(data)
-
-    return
-end
-
-
-Base.broadcastable(h::CUDAHist1D) = Ref(h)
-
-Statistics.mean(h::CUDAHist1D) = Statistics.mean(bincenters(h), Weights(bincounts(h)))
-Statistics.std(h::CUDAHist1D) = Statistics.mean((bincenters(h) .- mean(h)*CUDA.ones(length(bincenters(h)))).^2, Weights(bincounts(h))) |> sqrt 
-
-"""
-    normalize(h::CUDAHist1D; width=true)
-
-Create a normalized histogram via division by `integral(h)`, when `width==true`, the
-resultant histogram has area under the curve equals 1.
-
-!!! warning
-    Implicit approximation is made when using `width=true` with histograms
-    that have overflow bins: the overflow data lives inthe left/right most bins
-    and the bin width is taken "as is".
-"""
-function normalize(h::CUDAHist1D; width=true)
-    return h*(1/integral(h; width=width))
-end
-
-"""
-    cumulative(h::CUDAHist1D; forward=true)
-
-Create a cumulative histogram. If `forward`, start
-summing from the left.
-"""
-function cumulative(h::CUDAHist1D; forward=true)
-    # https://root.cern.ch/doc/master/TH1_8cxx_source.html#l02608
-    f = forward ? identity : reverse
-    h = deepcopy(h)
-    bc = bincounts(h)
-    bc .= f(cumsum(f(bc)))
-
-    s2 = sumw2(h)
-    s2 .= f(cumsum(f(s2)))
-    return h
+function move(backend, input)
+    # TODO replace with adapt(backend, input)
+    out = KernelAbstractions.allocate(backend, eltype(input), size(input))
+    KernelAbstractions.copyto!(backend, out, input)
+    return out
 end
 
 end

--- a/src/CUDAHist.jl
+++ b/src/CUDAHist.jl
@@ -23,7 +23,7 @@ end
 function gpu_bincounts(input; weights=nothing, sync=false, binedges, blocksize=256, backend=CUDABackend())
     cu_bincounts = KernelAbstractions.zeros(backend, Float32, length(binedges) - 1)
     firstr = Float32(first(binedges))
-    invstep = inv(step(binedges))
+    invstep = Float32(inv(step(binedges)))
     # binindexs = naive_binidxs(input, binedges)
     # synchronize(backend)
     histogram!(cu_bincounts, input, firstr, invstep; weights, blocksize)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,29 +96,42 @@ end
     @test isapprox(Array(cu_bcs), bincounts(hist_ref))
 end
 
-@testset "histogram tests" begin
-    rand_input = [rand(1:128) for i in 1:1000]
-    linear_input = [i for i in 1:1024]
-    all_two = [2 for i in 1:512]
+@testset "trivial integer binning (1000 bins)" begin
+    for N = 0:8
+        rand_input = Float32.(rand(1024 * 2^N))
+        binedges = 0:0.001:1
+        hist_ref = Hist1D(rand_input; binedges)
+        cu_input = move(backend, rand_input)
+        cu_bcs = gpu_bincounts(cu_input; binedges, backend)
+        KernelAbstractions.synchronize(backend)
 
-    histogram_rand_baseline = create_histogram(rand_input)
-    histogram_linear_baseline = create_histogram(linear_input)
-    histogram_two_baseline = create_histogram(all_two)
-
-    rand_input = move(backend, rand_input)
-    linear_input = move(backend, linear_input)
-    all_two = move(backend, all_two)
-
-    rand_histogram = KernelAbstractions.zeros(backend, Int, 128)
-    linear_histogram = KernelAbstractions.zeros(backend, Int, 1024)
-    two_histogram = KernelAbstractions.zeros(backend, Int, 2)
-
-    histogram!(rand_histogram, rand_input)
-    histogram!(linear_histogram, linear_input)
-    histogram!(two_histogram, all_two)
-    KernelAbstractions.synchronize(backend)
-
-    @test isapprox(Array(rand_histogram), histogram_rand_baseline)
-    @test isapprox(Array(linear_histogram), histogram_linear_baseline)
-    @test isapprox(Array(two_histogram), histogram_two_baseline)
+        @test isapprox(Array(cu_bcs), bincounts(hist_ref))
+    end
 end
+
+# @testset "histogram tests" begin
+#     rand_input = [rand(1:128) for i in 1:1000]
+#     linear_input = [i for i in 1:1024]
+#     all_two = [2 for i in 1:512]
+
+#     histogram_rand_baseline = create_histogram(rand_input)
+#     histogram_linear_baseline = create_histogram(linear_input)
+#     histogram_two_baseline = create_histogram(all_two)
+
+#     rand_input = move(backend, rand_input)
+#     linear_input = move(backend, linear_input)
+#     all_two = move(backend, all_two)
+
+#     rand_histogram = KernelAbstractions.zeros(backend, Int, 128)
+#     linear_histogram = KernelAbstractions.zeros(backend, Int, 1024)
+#     two_histogram = KernelAbstractions.zeros(backend, Int, 2)
+
+#     histogram!(rand_histogram, rand_input)
+#     histogram!(linear_histogram, linear_input)
+#     histogram!(two_histogram, all_two)
+#     KernelAbstractions.synchronize(backend)
+
+#     @test isapprox(Array(rand_histogram), histogram_rand_baseline)
+#     @test isapprox(Array(linear_histogram), histogram_linear_baseline)
+#     @test isapprox(Array(two_histogram), histogram_two_baseline)
+# end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Test
 using FHist
 using KernelAbstractions
 using CUDA
-using CUDAHist: gpu_bincounts, create_histogram, histogram!, move
+using CUDAHist: gpu_bincounts, histogram!, move
 const backend = isnothing(get(ENV, "CI", nothing)) ? CUDABackend() : CPU()
 
 # fhist = Hist1D(randn(1000))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,8 +98,8 @@ end
 
 @testset "trivial integer binning (1000 bins)" begin
     for N = 0:8
-        rand_input = Float32.(rand(1024 * 2^N))
-        binedges = 0:0.001:1
+        rand_input = Float32.(rand(1024 * 2^N)) .* 10
+        binedges = 0:0.1:100
         hist_ref = Hist1D(rand_input; binedges)
         cu_input = move(backend, rand_input)
         cu_bcs = gpu_bincounts(cu_input; binedges, backend)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,32 +1,70 @@
 using Test
 using FHist
-using CUDAHist
+using KernelAbstractions
+using CUDA
+using CUDAHist: gpu_bincounts, create_histogram, histogram!, move
+const backend = CUDABackend()
 
-fhist = Hist1D(randn(1000))
-cuda_hist = CUDAHist1D(fhist);
+# fhist = Hist1D(randn(1000))
+# cuda_hist = CUDAHist1D(fhist);
 
-@testset "Equality Tests" begin
-    @test fhist.overflow == cuda_hist.overflow
-    @test Vector(FHist.binedges(fhist)) == Vector(CUDAHist.binedges(cuda_hist))
-    @test FHist.bincounts(fhist) == Vector(CUDAHist.bincounts(cuda_hist))
-    @test FHist.bincenters(fhist) == Vector(CUDAHist.bincenters(cuda_hist))
-    @test FHist.sumw2(fhist) == Vector(CUDAHist.sumw2(cuda_hist))
-    @test FHist.nentries(fhist) == CUDAHist.nentries(cuda_hist)
-    @test FHist.binerrors(fhist) ≈ Vector(CUDAHist.binerrors(cuda_hist))
-    @test FHist.nbins(fhist) == CUDAHist.nbins(cuda_hist)
-    @test FHist.integral(fhist) == CUDAHist.integral(cuda_hist)
-    @test FHist.mean(fhist) ≈ CUDAHist.mean(cuda_hist)
-    @test FHist.std(fhist) ≈ CUDAHist.std(cuda_hist)
-    @test cuda_hist == fhist
+# warm up
+begin
+    wi_cpu = rand(1:128, 512)
+    Hist1D(wi_cpu; binedges=1:129)
+    wi = move(backend, wi_cpu)
+    wi_h = KernelAbstractions.zeros(backend, Int, 128)
+    histogram!(wi_h, wi)
+    KernelAbstractions.synchronize(backend)
 end
 
-@testset "Append Tests" begin
-    data = Float32.(randn(1000))
-    FHist.append!(fhist, data)
-    CUDAHist.append!(cuda_hist, data)
-    @test cuda_hist == fhist;
+@testset "basic binning" begin
+    be1 = [0, 1, 4]
+    data1 = [0.5]
 
-    CUDAHist.cuda_append!(cuda_hist, data, 100)
-    FHist.append!(fhist, data)
-    @test cuda_hist == fhist;
+    ref_hist1 = FHist.Hist1D(data1; binedges=be1)
+end
+
+@testset "trivial integer binning" begin
+    for N = 0:8
+        rand_input = rand(1:128, 1024 * 2^N)
+
+        binedges = 1:129
+        @info N
+        histogram_rand_baseline = @time Hist1D(rand_input; binedges)
+        rand_input = move(backend, rand_input)
+        @time begin
+            cu_bcs = gpu_bincounts(rand_input; binedges)
+            KernelAbstractions.synchronize(backend)
+        end
+
+        @test isapprox(Array(cu_bcs), bincounts(histogram_rand_baseline))
+    end
+end
+
+@testset "histogram tests" begin
+    rand_input = [rand(1:128) for i in 1:1000]
+    linear_input = [i for i in 1:1024]
+    all_two = [2 for i in 1:512]
+
+    histogram_rand_baseline = create_histogram(rand_input)
+    histogram_linear_baseline = create_histogram(linear_input)
+    histogram_two_baseline = create_histogram(all_two)
+
+    rand_input = move(backend, rand_input)
+    linear_input = move(backend, linear_input)
+    all_two = move(backend, all_two)
+
+    rand_histogram = KernelAbstractions.zeros(backend, Int, 128)
+    linear_histogram = KernelAbstractions.zeros(backend, Int, 1024)
+    two_histogram = KernelAbstractions.zeros(backend, Int, 2)
+
+    histogram!(rand_histogram, rand_input)
+    histogram!(linear_histogram, linear_input)
+    histogram!(two_histogram, all_two)
+    KernelAbstractions.synchronize(backend)
+
+    @test isapprox(Array(rand_histogram), histogram_rand_baseline)
+    @test isapprox(Array(linear_histogram), histogram_linear_baseline)
+    @test isapprox(Array(two_histogram), histogram_two_baseline)
 end


### PR DESCRIPTION
## TODO:
- [x] Using `CPU()` backend for CI testing
- [x] add binning support (right now the input are already bin index, which is unrealistic)
- [x] add per-input element weight support

```julia
 Test Summary: | Total  Time
basic binning |     0  0.2s
[ Info: 0
  0.000011 seconds (10 allocations: 2.422 KiB)
  0.379036 seconds (367.39 k allocations: 20.133 MiB, 58.78% compilation time)
[ Info: 1
  0.000011 seconds (10 allocations: 2.422 KiB)
  0.000139 seconds (240 allocations: 6.266 KiB)
[ Info: 2
  0.000010 seconds (10 allocations: 2.422 KiB)
  0.000074 seconds (240 allocations: 6.266 KiB)
[ Info: 3
  0.000022 seconds (10 allocations: 2.422 KiB)
  0.000056 seconds (240 allocations: 6.266 KiB)
[ Info: 4
  0.000042 seconds (10 allocations: 2.422 KiB)
  0.000060 seconds (240 allocations: 6.266 KiB)
[ Info: 5
  0.000072 seconds (10 allocations: 2.422 KiB)
  0.000058 seconds (240 allocations: 6.266 KiB)
[ Info: 6
  0.000145 seconds (10 allocations: 2.422 KiB)
  0.000060 seconds (240 allocations: 6.266 KiB)
[ Info: 7
  0.000278 seconds (10 allocations: 2.422 KiB)
  0.000062 seconds (240 allocations: 6.266 KiB)
[ Info: 8
  0.000601 seconds (10 allocations: 2.422 KiB)
  0.000134 seconds (240 allocations: 6.266 KiB)
Test Summary:           | Pass  Total  Time
trivial integer binning |    9      9  1.9s
[ Info: 1
  0.000007 seconds (10 allocations: 2.422 KiB)
  0.000121 seconds (228 allocations: 6.078 KiB)
[ Info: 2
  0.000002 seconds (10 allocations: 2.422 KiB)
  0.000058 seconds (228 allocations: 6.078 KiB)
[ Info: 3
  0.000002 seconds (10 allocations: 2.422 KiB)
  0.000051 seconds (228 allocations: 6.078 KiB)
[ Info: 4
  0.000002 seconds (10 allocations: 2.422 KiB)
  0.000088 seconds (228 allocations: 6.078 KiB)
[ Info: 10
  0.000002 seconds (10 allocations: 2.422 KiB)
  0.000092 seconds (228 allocations: 6.078 KiB)
[ Info: 128
  0.000002 seconds (10 allocations: 2.422 KiB)
  0.000052 seconds (228 allocations: 6.078 KiB)
[ Info: 1000
  0.000004 seconds (10 allocations: 2.422 KiB)
  0.000055 seconds (240 allocations: 6.266 KiB)
[ Info: 10000
  0.000022 seconds (10 allocations: 2.422 KiB)
  0.000057 seconds (240 allocations: 6.266 KiB)
Test Summary:      | Pass  Total  Time
weird input length |    8      8  0.0s
  0.000017 seconds (10 allocations: 2.422 KiB)
  0.273938 seconds (272.52 k allocations: 15.503 MiB, 38.73% compilation time)
  0.000028 seconds (10 allocations: 2.422 KiB)
  0.000117 seconds (250 allocations: 6.453 KiB)
  0.000046 seconds (10 allocations: 2.422 KiB)
  0.000061 seconds (250 allocations: 6.453 KiB)
  0.000090 seconds (10 allocations: 2.422 KiB)
  0.000057 seconds (250 allocations: 6.453 KiB)
  0.000176 seconds (10 allocations: 2.422 KiB)
  0.000059 seconds (250 allocations: 6.453 KiB)
  0.000375 seconds (10 allocations: 2.422 KiB)
  0.000061 seconds (250 allocations: 6.453 KiB)
  0.000745 seconds (10 allocations: 2.422 KiB)
  0.000065 seconds (250 allocations: 6.453 KiB)
  0.001402 seconds (10 allocations: 2.422 KiB)
  0.000076 seconds (250 allocations: 6.453 KiB)
  0.002834 seconds (10 allocations: 2.422 KiB)
  0.000174 seconds (250 allocations: 6.453 KiB)
Test Summary:                        | Pass  Total  Time
trivial integer binning with weights |    9      9  0.3s
Test Summary:  | Pass  Total  Time
simple binning |    1      1  0.2s
Test Summary:   | Pass  Total  Time
uniform binning |    1      1  0.9s
Test Summary:   | Pass  Total  Time
histogram tests |    3      3  1.2s
     Testing CUDAHist tests passed
```

![image](https://github.com/user-attachments/assets/0571cdb4-c893-4d3a-8cf4-d61b8354ad26)

